### PR TITLE
fix: use standard shadows

### DIFF
--- a/.changeset/lazy-impalas-lie.md
+++ b/.changeset/lazy-impalas-lie.md
@@ -1,0 +1,5 @@
+---
+"@verysimple/react": patch
+---
+
+use standard shadow classname

--- a/packages/react/src/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/react/src/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`Dialog closing 1`] = `
               >
                 <button
                   aria-label="Close"
-                  class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded min-w-[48px] shadow-sm hover:shadow-md disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] focus:bg-gray-300/20 hover:bg-gray-300/20 active:bg-gray-300/20 dark:focus:bg-gray-750/60 dark:hover:bg-gray-750/60 dark:active:bg-gray-750/60"
+                  class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded min-w-[48px] shadow hover:shadow disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] focus:bg-gray-300/20 hover:bg-gray-300/20 active:bg-gray-300/20 dark:focus:bg-gray-750/60 dark:hover:bg-gray-750/60 dark:active:bg-gray-750/60"
                   tabindex="0"
                 >
                   <svg

--- a/packages/react/src/Dialog/components/DialogCloseButton/__snapshots__/DialogCloseButton.test.tsx.snap
+++ b/packages/react/src/Dialog/components/DialogCloseButton/__snapshots__/DialogCloseButton.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DialogCloseButton snapshot 1`] = `
 <div>
   <button
     aria-label="Close"
-    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded min-w-[48px] shadow-sm hover:shadow-md disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] focus:bg-gray-300/20 hover:bg-gray-300/20 active:bg-gray-300/20 dark:focus:bg-gray-750/60 dark:hover:bg-gray-750/60 dark:active:bg-gray-750/60"
+    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded min-w-[48px] shadow hover:shadow disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] focus:bg-gray-300/20 hover:bg-gray-300/20 active:bg-gray-300/20 dark:focus:bg-gray-750/60 dark:hover:bg-gray-750/60 dark:active:bg-gray-750/60"
     tabindex="0"
   >
     <svg

--- a/packages/react/src/FilledButton/__snapshots__/FilledButton.test.tsx.snap
+++ b/packages/react/src/FilledButton/__snapshots__/FilledButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FilledButton should have a red background if destructive 1`] = `
 <div>
   <button
-    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded transition-colors duration-200 ease-in-out whitespace-nowrap font-bold shadow-sm hover:shadow-md disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] bg-red-500 disabled:bg-red-400 disabled:text-white px-4 text-white"
+    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded transition-colors duration-200 ease-in-out whitespace-nowrap font-bold shadow hover:shadow disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] bg-red-500 disabled:bg-red-400 disabled:text-white px-4 text-white"
     tabindex="0"
   />
 </div>

--- a/packages/react/src/FilledButtonBase/__snapshots__/FilledButtonBase.test.tsx.snap
+++ b/packages/react/src/FilledButtonBase/__snapshots__/FilledButtonBase.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FilledButtonBase should have a red background if destructive 1`] = `
 <div>
   <button
-    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded transition-colors duration-200 ease-in-out whitespace-nowrap font-bold shadow-sm hover:shadow-md disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] bg-red-500 disabled:bg-red-400 disabled:text-white"
+    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded transition-colors duration-200 ease-in-out whitespace-nowrap font-bold shadow hover:shadow disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] bg-red-500 disabled:bg-red-400 disabled:text-white"
     tabindex="0"
   />
 </div>

--- a/packages/react/src/FilledIconButton/__snapshots__/FilledIconButton.test.tsx.snap
+++ b/packages/react/src/FilledIconButton/__snapshots__/FilledIconButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FilledIconButton should be fully rounded 1`] = `
 <div>
   <button
-    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded transition-colors duration-200 ease-in-out whitespace-nowrap font-bold shadow-sm hover:shadow-md disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] bg-foreground rounded-full min-w-[48px]"
+    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded transition-colors duration-200 ease-in-out whitespace-nowrap font-bold shadow hover:shadow disabled:shadow-none transition-shadow ease-in duration-100 text-base min-h-[44px] bg-foreground rounded-full min-w-[48px]"
     tabindex="0"
   >
     Test

--- a/packages/react/src/Input/Input.tsx
+++ b/packages/react/src/Input/Input.tsx
@@ -53,8 +53,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             "border my-border": !containerClassname.includes("border-"),
             "w-full": fullWidth,
             [shadowTransitionClassNames(className)]: !disabled,
-            "shadow-sm focus-within:shadow-md hover:shadow-md disabled:shadow-none":
-              !disabled,
+            "shadow focus-within:shadow hover:shadow disabled:shadow-none": !disabled,
           },
           containerClassname
         )}

--- a/packages/react/src/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/react/src/Input/__snapshots__/Input.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Input should not have a gradient border if disable focus style is true 1`] = `
 <div>
   <div
-    class="rounded inline-flex items-center overflow-hidden border my-border transition-shadow ease-in duration-100 shadow-sm focus-within:shadow-md hover:shadow-md disabled:shadow-none"
+    class="rounded inline-flex items-center overflow-hidden border my-border transition-shadow ease-in duration-100 shadow focus-within:shadow hover:shadow disabled:shadow-none"
   >
     <div
       class="w-full relative inline-flex items-center"
@@ -19,7 +19,7 @@ exports[`Input should not have a gradient border if disable focus style is true 
 exports[`Input should not have a gradient border if disable focus style is true 2`] = `
 <div>
   <div
-    class="rounded inline-flex items-center overflow-hidden border my-border transition-shadow ease-in duration-100 shadow-sm focus-within:shadow-md hover:shadow-md disabled:shadow-none"
+    class="rounded inline-flex items-center overflow-hidden border my-border transition-shadow ease-in duration-100 shadow focus-within:shadow hover:shadow disabled:shadow-none"
   >
     <div
       class="w-full relative inline-flex items-center"
@@ -52,7 +52,7 @@ exports[`Input should not have shadow classnames when disabled 1`] = `
 exports[`Input should render 1`] = `
 <div>
   <div
-    class="rounded inline-flex items-center overflow-hidden border my-border transition-shadow ease-in duration-100 shadow-sm focus-within:shadow-md hover:shadow-md disabled:shadow-none"
+    class="rounded inline-flex items-center overflow-hidden border my-border transition-shadow ease-in duration-100 shadow focus-within:shadow hover:shadow disabled:shadow-none"
   >
     <div
       class="w-full relative inline-flex items-center"

--- a/packages/react/src/NormalIconButton/NormalIconButton.test.tsx
+++ b/packages/react/src/NormalIconButton/NormalIconButton.test.tsx
@@ -7,9 +7,9 @@ describe("NormalIconButton", () => {
     render(<NormalIconButton />);
     expect(screen.getByRole("button")).toHaveClass("min-w-[48px]");
   });
-  it("should have button shadows", () => {
+  it("should have a shadow", () => {
     render(<NormalIconButton />);
-    expect(screen.getByRole("button")).toHaveClass("shadow-sm");
+    expect(screen.getByRole("button")).toHaveClass("shadow");
   });
   it("forwards the ref", () => {
     const ref = createRef<HTMLButtonElement>();

--- a/packages/react/src/OutlinedButton/__snapshots__/OutlinedButton.test.tsx.snap
+++ b/packages/react/src/OutlinedButton/__snapshots__/OutlinedButton.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`OutlinedButton can render as a custom component when primary and disabl
 exports[`OutlinedButton should have an outline 1`] = `
 <div>
   <button
-    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded border shadow-sm hover:shadow-md disabled:shadow-none transition-shadow ease-in duration-100 whitespace-nowrap font-bold text-base min-h-[44px] my-border box-content"
+    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded border shadow hover:shadow disabled:shadow-none transition-shadow ease-in duration-100 whitespace-nowrap font-bold text-base min-h-[44px] my-border box-content"
     tabindex="0"
   >
     <span

--- a/packages/react/src/OutlinedButtonBase/__snapshots__/OutlinedButtonBase.test.tsx.snap
+++ b/packages/react/src/OutlinedButtonBase/__snapshots__/OutlinedButtonBase.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OutlinedButtonBase should have an outline 1`] = `
 <div>
   <button
-    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded border shadow-sm hover:shadow-md disabled:shadow-none transition-shadow ease-in duration-100 whitespace-nowrap font-bold text-base min-h-[44px] my-border box-content"
+    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded border shadow hover:shadow disabled:shadow-none transition-shadow ease-in duration-100 whitespace-nowrap font-bold text-base min-h-[44px] my-border box-content"
     tabindex="0"
   >
     Test

--- a/packages/react/src/OutlinedIconButton/__snapshots__/OutlinedIconButton.test.tsx.snap
+++ b/packages/react/src/OutlinedIconButton/__snapshots__/OutlinedIconButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`OutlinedIconButton should have an outline 1`] = `
 <div>
   <button
-    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded border shadow-sm hover:shadow-md disabled:shadow-none transition-shadow ease-in duration-100 whitespace-nowrap font-bold text-base min-h-[44px] my-border box-content min-w-[48px]"
+    class="focus:outline-none cursor-pointer disabled:cursor-not-allowed inline-flex items-center justify-center rounded border shadow hover:shadow disabled:shadow-none transition-shadow ease-in duration-100 whitespace-nowrap font-bold text-base min-h-[44px] my-border box-content min-w-[48px]"
     tabindex="0"
   >
     Test

--- a/packages/react/src/helpers/__tests__/buttonShadowClassNames.test.ts
+++ b/packages/react/src/helpers/__tests__/buttonShadowClassNames.test.ts
@@ -3,13 +3,13 @@ import { buttonShadowClassNames } from "../buttonShadowClassNames";
 describe("buttonShadowClassNames", () => {
   it("should return the default", () => {
     expect(buttonShadowClassNames("filled", "not-an-override")).toContain(
-      "shadow-sm"
+      "shadow"
     );
   });
   it("should be overridable", () => {
     expect(buttonShadowClassNames("filled", "shadow-none")).toBe("");
   });
   it("doesn't fail if the className is undefined", () => {
-    expect(buttonShadowClassNames("filled")).toContain("shadow-sm");
+    expect(buttonShadowClassNames("filled")).toContain("shadow");
   });
 });

--- a/packages/react/src/helpers/buttonShadowClassNames.ts
+++ b/packages/react/src/helpers/buttonShadowClassNames.ts
@@ -9,7 +9,7 @@ export const buttonShadowClassNames = (
     ? ""
     : clsx(
         {
-          "shadow-sm hover:shadow-md disabled:shadow-none":
+          "shadow hover:shadow disabled:shadow-none":
             variant === "filled" ||
             variant === "outlined" ||
             variant === "normal",


### PR DESCRIPTION
This enables global configuration via the following:

```
// tailwind config
boxShadow: {
    DEFAULT: "var(--box-shadow)",
}
```


```css
/* global.css */
:root {
  --box-shadow: none;
}
```


